### PR TITLE
add kickoff queues to the normal worker

### DIFF
--- a/Boltdir/modules/dashboard/manifests/app.pp
+++ b/Boltdir/modules/dashboard/manifests/app.pp
@@ -111,7 +111,8 @@ class dashboard::app (
       'C_FORCE_ROOT=1',
       "SENTRY_DSN=${sentry_dsn}",
     ],
-    command               => 'celery_dashboard worker -Q storage,celery,isolated',
+    # for some reason redis tells us that kickoff3 exists, might be a glitch and that it's just kickoff...
+    command               => 'celery_dashboard worker -Q storage,celery,isolated,kickoff,kickoff1,kickoff2,kickoff3,kickoff4',
   }
 
   ::docker::run { 'dashboard-worker-reporting':


### PR DESCRIPTION
No new worker is created as the number of tasks on this instance is low and the amount of memory on this server is also limited