### PR TITLE
[wip] all account management is now performed via an api [5.2.0 and up]

### DIFF
--- a/Boltdir/data/env/staging.yaml
+++ b/Boltdir/data/env/staging.yaml
@@ -5,6 +5,20 @@ dashboard::le_staging: false
 dashboard::app::image_tag: latest
 # how often to check for docker image update
 dashboard::app::auto_update_interval: 5min
+# we're changing authentication paths in 5.2.0
+dashboard:app::dynamic_content_paths: join([
+    '/admin/',
+    '/api/',
+    '/data/',
+    '/jet/',
+    '/logout',
+    '/mail/',
+    '/session/',
+    '/static/',
+    '/upload/',
+    '/security.txt',
+    '/.well-known/security.txt'
+  ], '|')
 
 # explicitly set fixed IPv6 address bound to domain name, other IPv6 addresses
 # and gateway are obtained through RA

--- a/Boltdir/modules/dashboard/manifests/app.pp
+++ b/Boltdir/modules/dashboard/manifests/app.pp
@@ -34,6 +34,8 @@ class dashboard::app (
 
   # all paths that should be routed to Django dynamic backend
   $dynamic_content_paths = join([
+    '/accounts/',
+    '/account/',
     '/admin/',
     '/api/',
     '/data/',

--- a/Boltdir/modules/dashboard/manifests/app.pp
+++ b/Boltdir/modules/dashboard/manifests/app.pp
@@ -34,8 +34,6 @@ class dashboard::app (
 
   # all paths that should be routed to Django dynamic backend
   $dynamic_content_paths = join([
-    '/accounts/',
-    '/account/',
     '/admin/',
     '/api/',
     '/data/',


### PR DESCRIPTION
This cannot be merged yet, as it will break authentication paths. Authentication in dashboard 5.2.0 is done via an API and not via exposing django pages.